### PR TITLE
Quitar la opción "guías" del menu

### DIFF
--- a/src/app/mock-api/common/navigation/data.ts
+++ b/src/app/mock-api/common/navigation/data.ts
@@ -29,13 +29,13 @@ export const defaultNavigation: FuseNavigationItem[] = [
                         icon    : 'heroicons_outline:shopping-cart',
                         link : '/dafiti/orders'
                     },
-                    {
+                    /*{
                         id   : 'dafiti.inf.tracking',
                         title: 'Guias',
                         type : 'basic',
                         icon    : 'heroicons_outline:shopping-cart',
                         link : '/dafiti/tracking'
-                    },
+                    },*/
                     {
                         id   : 'dafiti.inf.crossdocking',
                         title: 'Crossdocking',


### PR DESCRIPTION
Se da cumplimiento al item 1 del JDO-178 Generar el funcionamiento del submenú guías.